### PR TITLE
🔧 (config): switch to debug mode in .air.toml for development

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -12,8 +12,8 @@ tmp_dir = "dist"
   exclude_regex = ["_test.go"]
   exclude_unchanged = false
   follow_symlink = false
-  full_bin = "GIN_MODE=release ./dist/go_news_api"
-  # full_bin = "GIN_MODE=debug ./dist/go_news_api"
+  # full_bin = "GIN_MODE=release ./dist/go_news_api"
+  full_bin = "GIN_MODE=debug ./dist/go_news_api"
   include_dir = []
   include_ext = ["go", "tpl", "tmpl", "html"]
   include_file = []

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -423,9 +423,9 @@ const docTemplate = `{
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "1.0",
-	Host:             "localhost:8823",
+	Host:             "localhost:8824",
 	BasePath:         "/api/v1",
-	Schemes:          []string{"http"},
+	Schemes:          []string{"http", "https"},
 	Title:            "News API",
 	Description:      "A simple news API using Gin and external news services",
 	InfoInstanceName: "swagger",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,6 +1,7 @@
 {
     "schemes": [
-        "http"
+        "http",
+        "https"
     ],
     "swagger": "2.0",
     "info": {
@@ -9,7 +10,7 @@
         "contact": {},
         "version": "1.0"
     },
-    "host": "localhost:8823",
+    "host": "localhost:8824",
     "basePath": "/api/v1",
     "paths": {
         "/fetch-trending-categories": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -105,7 +105,7 @@ definitions:
       updatedAt:
         type: string
     type: object
-host: localhost:8823
+host: localhost:8824
 info:
   contact: {}
   description: A simple news API using Gin and external news services
@@ -271,4 +271,5 @@ paths:
       summary: Get trending topics news
 schemes:
 - http
+- https
 swagger: "2.0"

--- a/main.go
+++ b/main.go
@@ -34,9 +34,9 @@ import (
 // @BasePath /api/v1
 // @schemes https
 
-// @host localhost:8823
+// @host localhost:8824
 // @BasePath /api/v1
-// @schemes http
+// @schemes http https
 func main() {
 
 	// Load .env file


### PR DESCRIPTION
🌐 (docs): update Swagger documentation to support HTTPS and change host port

Switching to debug mode in `.air.toml` facilitates easier development and debugging. Updating the Swagger documentation to support HTTPS and changing the host port from 8823 to 8824 ensures the API documentation reflects the current server configuration and supports secure connections.