### PR TITLE
🔧 (latest-changes.yml): update GitHub Actions workflow permissions for latest-changes job

### DIFF
--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -4,7 +4,6 @@ on:
   pull_request_target:
     branches:
       - main
-
     types:
       - closed
 
@@ -17,6 +16,9 @@ on:
 jobs:
   latest-changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
       - uses: docker://tiangolo/latest-changes:0.2.1


### PR DESCRIPTION
Remove unnecessary blank line and add specific permissions for the latest-changes job. The permissions for contents (write) and pull-requests (read) are added to ensure the workflow has the necessary access to update contents and read pull request data. This enhances security by limiting the scope of permissions to only what is needed.