### PR TITLE
🔧 (todo-to-issue.yml): fix escape sequences in language block comment patterns

### DIFF
--- a/.github/workflows/todo-to-issue.yml
+++ b/.github/workflows/todo-to-issue.yml
@@ -24,7 +24,7 @@ jobs:
           MANUAL_BASE_REF: ${{ github.event.inputs.MANUAL_BASE_REF }}
         with:
           AUTO_ASSIGN: true
-          LANGUAGES: >
+          LANGUAGES: |
             [
               {
                 "language": "Go",
@@ -37,8 +37,8 @@ jobs:
                   {
                     "type": "block",
                     "pattern": {
-                      "start": "/\\\\*",
-                      "end": "\\\\*/"
+                      "start": "/\\*",
+                      "end": "\\*/"
                     }
                   }
                 ]


### PR DESCRIPTION
Corrects the escape sequences for block comment patterns in the todo-to-issue workflow configuration. This ensures that the patterns are correctly interpreted, allowing the workflow to properly identify and process TODO comments in Go code.