### PR TITLE
🔧 (automerge.yml): update automerge workflow to trigger on more events and improve merge commit message

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -6,6 +6,14 @@ on:
       - opened
       - synchronize
       - reopened
+      - unlabeled
+      - labeled
+  push:
+    branches:
+      - main
+  issue_comment:
+    types:
+      - created
   workflow_dispatch:
 
 jobs:
@@ -21,11 +29,11 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.PAT }}"
           LOG: "DEBUG"
           MERGE_LABELS: "automerge"
-          MERGE_REMOVE_LABELS: ""
+          MERGE_REMOVE_LABELS: "automerge"
           MERGE_METHOD: "merge"
           MERGE_REQUIRED_APPROVALS: "0"
           MERGE_DELETE_BRANCH: "true"
-          MERGE_COMMIT_MESSAGE: "automatic"
+          MERGE_COMMIT_MESSAGE: "Auto merge PR #{pullRequest.number}: {pullRequest.title}|{pullRequest.description}"
           MERGE_FORKS: "true"
           MERGE_RETRIES: "1"
           MERGE_RETRY_SLEEP: "5000"


### PR DESCRIPTION
Add triggers for `unlabeled`, `labeled`, `push` to `main`, and `issue_comment` events to ensure the automerge workflow runs in more scenarios. Update `MERGE_REMOVE_LABELS` to remove the `automerge` label after merging, and enhance `MERGE_COMMIT_MESSAGE` to include PR number, title, and description for better traceability.