### PR TITLE
🔧 (workflows): add GitHub Actions workflows for build, release, and changelog generation

### DIFF
--- a/.github/workflows/build-release-go-binary.yml
+++ b/.github/workflows/build-release-go-binary.yml
@@ -1,0 +1,45 @@
+name: Build and Release Go Binary
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.22.5'
+
+    - name: Build
+      run: |
+        go mod tidy
+        go build -o go_news_api -ldflags="-w -s -X main.Version=${GITHUB_REF#refs/tags/}" .
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
+
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./go_news_api
+        asset_name: go_news_api
+        asset_content_type: application/octet-stream

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -1,0 +1,29 @@
+name: Generate Changelog
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  generate_changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Generate Changelog
+      uses: heinrichreimer/action-github-changelog-generator@v2.4
+      with:
+        token: ${{ secrets.PAT }}
+        output: CHANGELOG.md
+        issues: true
+        issuesWoLabels: true
+        pullRequests: true
+        prWoLabels: true
+        unreleased: true
+        compareLink: true
+        excludeLabels: duplicate,question,invalid,wontfix
+    - name: Commit Changelog
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Update CHANGELOG.md
+        file_pattern: CHANGELOG.md

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,14 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}


### PR DESCRIPTION
Introduce three new GitHub Actions workflows to automate the build and release process for the Go binary, generate changelogs, and draft releases. The `build-release-go-binary.yml` workflow builds and releases the Go binary upon tagging. The `generate-changelog.yml` workflow generates a changelog on pushes to the main branch. The `release-drafter.yml` workflow drafts a release on pushes to the main branch. These changes aim to streamline the release process and ensure consistent documentation.