### PR TITLE
✨ (endpoints): add endpoint to fetch news by keyword with pagination support

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -122,6 +122,56 @@ const docTemplate = `{
                 }
             }
         },
+        "/news-by-keyword": {
+            "get": {
+                "description": "Get news articles for a specific keyword from News API and GNews",
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Get news by keyword",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source of news (newsapi or gnews)",
+                        "name": "source",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Keyword to search for",
+                        "name": "keyword",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/utils.SwaggerAPIResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/test-postgresql": {
             "get": {
                 "description": "Test if the connection to PostgreSQL is working",
@@ -379,6 +429,12 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/utils.Article"
                     }
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "per_page": {
+                    "type": "integer"
                 },
                 "status": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -120,6 +120,56 @@
                 }
             }
         },
+        "/news-by-keyword": {
+            "get": {
+                "description": "Get news articles for a specific keyword from News API and GNews",
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Get news by keyword",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source of news (newsapi or gnews)",
+                        "name": "source",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Keyword to search for",
+                        "name": "keyword",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/utils.SwaggerAPIResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/test-postgresql": {
             "get": {
                 "description": "Test if the connection to PostgreSQL is working",
@@ -377,6 +427,12 @@
                     "items": {
                         "$ref": "#/definitions/utils.Article"
                     }
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "per_page": {
+                    "type": "integer"
                 },
                 "status": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -81,6 +81,10 @@ definitions:
         items:
           $ref: '#/definitions/utils.Article'
         type: array
+      page:
+        type: integer
+      per_page:
+        type: integer
       status:
         type: string
       totalArticles:
@@ -182,6 +186,39 @@ paths:
               type: string
             type: object
       summary: Migrate database
+  /news-by-keyword:
+    get:
+      description: Get news articles for a specific keyword from News API and GNews
+      parameters:
+      - description: Source of news (newsapi or gnews)
+        in: query
+        name: source
+        type: string
+      - description: Keyword to search for
+        in: query
+        name: keyword
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/utils.SwaggerAPIResponse'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get news by keyword
   /test-postgresql:
     get:
       description: Test if the connection to PostgreSQL is working

--- a/endpoints/search_keyword.go
+++ b/endpoints/search_keyword.go
@@ -1,0 +1,89 @@
+package endpoints
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"go_news_api/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GetNewsByKeyword handles the request for news articles by keyword
+func GetNewsByKeyword(c *gin.Context) {
+	keyword := c.Query("keyword")
+	page, perPage := GetPaginationParams(c)
+
+	if keyword == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Keyword is required"})
+		return
+	}
+
+	searchQuery := PrepareSearchQuery(keyword)
+	articles, total, err := SearchArticles(searchQuery, page, perPage)
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	apiResponse := CreateAPIResponse(articles, total, page, perPage)
+	c.JSON(http.StatusOK, apiResponse)
+}
+
+func GetPaginationParams(c *gin.Context) (int, int) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	perPage, _ := strconv.Atoi(c.DefaultQuery("per_page", "20"))
+
+	if page < 1 {
+		page = 1
+	}
+	if perPage < 1 || perPage > 100 {
+		perPage = 20
+	}
+
+	return page, perPage
+}
+
+func PrepareSearchQuery(keyword string) string {
+	return strings.Join(strings.Fields(keyword), " & ")
+}
+
+func SearchArticles(searchQuery string, page, perPage int) ([]utils.Article, int64, error) {
+	offset := (page - 1) * perPage
+	var articles []utils.Article
+	var total int64
+
+	query := utils.DB.Model(&utils.Article{}).
+		Joins("LEFT JOIN sources ON articles.source_id = sources.id").
+		Where("to_tsvector('english', articles.author || ' ' || articles.title || ' ' || articles.description || ' ' || articles.content) @@ to_tsquery('english', ?)", searchQuery).
+		Order(fmt.Sprintf("ts_rank(to_tsvector('english', articles.author || ' ' || articles.title || ' ' || articles.description || ' ' || articles.content), to_tsquery('english', '%s')) DESC", searchQuery))
+
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	result := query.Preload("Source").
+		Offset(offset).
+		Limit(perPage).
+		Find(&articles)
+
+	if result.Error != nil {
+		return nil, 0, result.Error
+	}
+
+	return articles, total, nil
+}
+
+func CreateAPIResponse(articles []utils.Article, total int64, page, perPage int) *utils.APIResponse {
+	return &utils.APIResponse{
+		Status:        "ok",
+		TotalResults:  int(total),
+		TotalArticles: len(articles),
+		Articles:      articles,
+		Page:          page,
+		PerPage:       perPage,
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,8 +1,5 @@
 package main
 
-// TODO: add endpoints for fetching news by keyword
-// labels: endpoint, feature, enhancement
-
 // TODO: add endpoints for fetching news by search query
 // labels: endpoint, feature, enhancement
 
@@ -80,6 +77,7 @@ func main() {
 		v1.GET("/top-headlines", getTopHeadlines)
 		v1.GET("/trending-topics", getTrendingTopicsNews)
 		v1.GET("/fetch-trending-categories", fetchTrendingCategories)
+		v1.GET("/news-by-keyword", getNewsByKeyword)
 	}
 
 	// Modify the Swagger documentation route
@@ -342,4 +340,17 @@ func fetchTrendingCategories(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, trendingTopics)
+}
+
+// @Summary Get news by keyword
+// @Description Get news articles for a specific keyword from News API and GNews
+// @Produce json
+// @Param source query string false "Source of news (newsapi or gnews)"
+// @Param keyword query string true "Keyword to search for"
+// @Success 200 {object} utils.SwaggerAPIResponse
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /news-by-keyword [get]
+func getNewsByKeyword(c *gin.Context) {
+	endpoints.GetNewsByKeyword(c)
 }

--- a/utils/models.go
+++ b/utils/models.go
@@ -16,6 +16,8 @@ type APIResponse struct {
 	APISource     string    `json:"api_source"` // "gnews" or "newsapi"
 	Type          string    `json:"type"`       // "category" or "topic"
 	Topic         string    `json:"topic,omitempty"`
+	Page          int       `json:"page,omitempty"`
+	PerPage       int       `json:"per_page,omitempty"`
 }
 type Article struct {
 	gorm.Model
@@ -114,4 +116,6 @@ type SwaggerAPIResponse struct {
 	TotalArticles int       `json:"totalArticles"`
 	Articles      []Article `json:"articles"`
 	APISource     string    `json:"apiSource"`
+	Page          int       `json:"page,omitempty"`
+	PerPage       int       `json:"per_page,omitempty"`
 }


### PR DESCRIPTION
Add a new endpoint `/news-by-keyword` to fetch news articles based on a keyword
from News API and GNews. This includes updating the Swagger documentation to
reflect the new endpoint and its parameters. The endpoint supports pagination
with `page` and `per_page` query parameters.

This change enhances the API by allowing users to search for news articles
using specific keywords, improving the usability and functionality of the
service. Pagination support ensures efficient data handling and better user
experience.