### PR TITLE
chore: Add support for building the application for ARM64 architecture

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -49,6 +49,8 @@ jobs:
         GOOS=linux GOARCH=amd64 go build -v -o build/go_news_api_linux_amd64 .
         GOOS=darwin GOARCH=amd64 go build -v -o build/go_news_api_darwin_amd64 .
         GOOS=windows GOARCH=amd64 go build -v -o build/go_news_api_windows_amd64.exe .
+        GOOS=linux GOARCH=aarch64 go build -v -o build/go_news_api_linux_arm64 .
+        GOOS=darwin GOARCH=aarch64 go build -v -o build/go_news_api_darwin_arm64 .
         
     - name: Bump version and push tag
       id: tag_version


### PR DESCRIPTION
This commit adds the necessary build steps to compile the application for the ARM64 architecture on both Linux and macOS. This ensures compatibility with ARM64-based systems and expands the range of platforms the application can run on.